### PR TITLE
Add Windows packaging support using pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ npm start
 Commands: `/play`, `/playnext`, `/skip`, `/pause`, `/resume`, `/stop`, `/queue`, `/leave`.
 
 This build includes `@snazzah/davey` so @discordjs/voice v0.19 can negotiate **DAVE** encryption when Discord requires it.
+
+## Packaged Windows executable
+To build a self-contained Windows binary with [`pkg`](https://github.com/vercel/pkg):
+
+```
+npm install
+npm run build:win
+```
+
+The command produces `dist/discord-music-bot.exe`, which embeds the bot and its Node.js runtime. Place your `.env` file next to
+the executable (or set environment variables globally) before launching.
+
+> **External tools still required**: `yt-dlp.exe` and `ffmpeg.exe` are not bundled by `pkg`. Keep them on your `PATH` or copy
+> them alongside the generated EXE, updating `YTDLP_PATH` / `FFMPEG_PATH` in `.env` if you store them elsewhere.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "discord.js": "^14.22.1",
         "dotenv": "^16.6.1",
         "express": "^4.21.2"
+      },
+      "devDependencies": {
+        "pkg": "^5.8.1"
       }
     },
     "node_modules/@discordjs/builders": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node --max-old-space-size=4096 index.js"
+    "start": "node --max-old-space-size=4096 index.js",
+    "build:win": "pkg . --targets node18-win-x64 --output dist/discord-music-bot.exe"
   },
   "dependencies": {
     "@discordjs/voice": "^0.19.0",
@@ -12,5 +13,16 @@
     "discord.js": "^14.22.1",
     "dotenv": "^16.6.1",
     "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "pkg": "^5.8.1"
+  },
+  "pkg": {
+    "scripts": [
+      "index.js"
+    ],
+    "assets": [
+      "README.md"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add the pkg bundler to dev dependencies and configure it to package index.js
- expose an npm script for building a Windows executable with pkg
- document how to build and run the packaged executable plus required yt-dlp/ffmpeg binaries

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/pkg)*

------
https://chatgpt.com/codex/tasks/task_e_68d863316b988333b52667a957b8a46a